### PR TITLE
Ajout de Vite React

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "resume-manager",
   "version": "1.0.0",
@@ -14,6 +13,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "vite": "^4.4.0"
+    "vite": "^4.4.0",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Notes
- L'installation de `@vitejs/plugin-react` a échoué faute d'accès au registre npm.

## Summary
- ajoute le plugin React dans `vite.config.js`
- inscrit `@vitejs/plugin-react` dans `package.json`

## Testing
- `npm run frontend` *(échoue: `vite` introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6840d593695c832e943b4f88f5aba859