### PR TITLE
Ajout d'un fichier .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.env
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+


### PR DESCRIPTION
## Summary
- ajoute un fichier `.gitignore` à la racine pour ignorer `node_modules/`, `dist/` ainsi que d'autres fichiers temporaires

## Testing
- `npm test` *(échoue: script manquant)*

------
https://chatgpt.com/codex/tasks/task_e_6840d5944f64832e9a548ca2f6b29aee