### PR TITLE
Fix command injection in export API

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 
 const app = express();
@@ -11,13 +12,33 @@ app.use(express.static(path.join(__dirname)));
 // Endpoint API pour exporter le CV
 app.get('/api/export', (req, res) => {
   const { theme, format, filename } = req.query;
-  const command = `resume export ${filename}.${format} --theme ${theme}`;
-  
-  exec(command, (error) => {
-    if (error) {
-      return res.status(500).send(`Erreur : ${error.message}`);
+
+  const allowedThemes = ['elegant', 'caffeine'];
+  const allowedFormats = ['pdf', 'html'];
+
+  const safeTheme = allowedThemes.includes(theme) ? theme : null;
+  const safeFormat = allowedFormats.includes(format) ? format : null;
+  const safeFilename = filename && /^[a-zA-Z0-9_-]+$/.test(filename) ? filename : null;
+
+  if (!safeTheme || !safeFormat || !safeFilename) {
+    return res.status(400).send('Param\u00e8tres invalides');
+  }
+
+  const args = ['export', `${safeFilename}.${safeFormat}`, '--theme', safeTheme];
+  const child = spawn('resume', args);
+
+  child.on('close', (code) => {
+    if (code !== 0) {
+      return res.status(500).send(`Erreur : code ${code}`);
     }
-    res.download(path.join(__dirname, `${filename}.${format}`));
+
+    const filePath = path.join(__dirname, `${safeFilename}.${safeFormat}`);
+    fs.access(filePath, fs.constants.F_OK, (err) => {
+      if (err) {
+        return res.status(500).send('Erreur : fichier non g\u00e9n\u00e9r\u00e9');
+      }
+      res.download(filePath);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- sanitize params for `/api/export`
- ensure exported file exists before sending it

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840d595ea10832eb5a9944c22f8176e