### PR TITLE
Ajout exemple resume.json et README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # CV
+
+Ce projet permet de générer un CV à partir d'un fichier `resume.json`.
+
+## Exemple de fichier `resume.json`
+
+Un exemple minimal est fourni à la racine du dépôt :
+
+```json
+{
+  "basics": {
+    "name": "John Doe",
+    "label": "Développeur"
+  }
+}
+```
+
+Placez votre propre fichier `resume.json` à la racine du projet pour qu'il soit utilisé par la commande `resume export`.
+

--- a/resume.json
+++ b/resume.json
@@ -1,0 +1,7 @@
+{
+  "basics": {
+    "name": "John Doe",
+    "label": "Développeur"
+  }
+}
+


### PR DESCRIPTION
## Notes
- Ajout d'un fichier `resume.json` minimal pour montrer la structure attendue.
- Mise à jour du `README.md` pour expliquer où placer ce fichier et fournir un exemple.

## Testing
- `npm test` *(échoue : Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6840d5975718832e9b8bf5f616107237