### PR TITLE
Ajout import JSON et preview CV

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Cette application fournit une petite API Express pour générer un CV puis le télécharger. Une page HTML simple permet de lancer l'export directement depuis le navigateur.
 
+Cette version ajoute la possibilité d'importer un fichier JSON décrivant votre CV,
+de choisir un thème, de prévisualiser le rendu et d'exporter le tout en PDF ou HTML.
+
 ## Installation
 
 ```bash
@@ -21,3 +24,11 @@ Ensuite ouvrez `http://localhost:5000` dans un navigateur pour accéder à l'int
 ### `GET /api/export`
 
 Cette route prend en paramètre `theme`, `format` et `filename`. Elle exécute la commande `resume export` pour générer le fichier demandé (PDF ou HTML) avec le thème sélectionné, puis le renvoie en téléchargement.
+
+### `POST /api/upload`
+
+Envoie le contenu d'un fichier JSON contenant votre CV. Le corps de la requête doit être le JSON. Le fichier est enregistré côté serveur et utilisé pour les exports et aperçus.
+
+### `GET /api/preview`
+
+Prend un paramètre `theme` et renvoie une page HTML générée à partir du CV importé. Cette route est utilisée pour l'aperçu en ligne dans l'interface.

--- a/index.html
+++ b/index.html
@@ -6,14 +6,39 @@
 </head>
 <body>
   <h1>Resume Manager</h1>
+  <input type="file" id="resume-file" accept="application/json" />
+  <button id="upload">Importer JSON</button>
   <input id="filename" placeholder="Nom du fichier" />
   <select id="theme">
     <option value="elegant">elegant</option>
     <option value="caffeine">caffeine</option>
   </select>
+  <button id="preview-html">Prévisualiser</button>
   <button id="export-pdf">Exporter PDF</button>
   <button id="export-html">Exporter HTML</button>
+  <div id="preview-container">
+    <iframe id="preview" style="width:100%;height:600px"></iframe>
+  </div>
   <script>
+    async function upload() {
+      const input = document.getElementById('resume-file');
+      if (!input.files.length) {
+        alert('Sélectionnez un fichier JSON');
+        return;
+      }
+      const text = await input.files[0].text();
+      const res = await fetch('/api/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: text
+      });
+      if (!res.ok) {
+        alert('Erreur: ' + await res.text());
+        return;
+      }
+      alert('CV importé');
+    }
+
     async function exporter(format) {
       const filename = document.getElementById('filename').value || 'cv';
       const theme = document.getElementById('theme').value;
@@ -30,8 +55,15 @@
       a.click();
       URL.revokeObjectURL(url);
     }
+    function preview() {
+      const theme = document.getElementById('theme').value;
+      document.getElementById('preview').src = `/api/preview?theme=${theme}`;
+    }
+
+    document.getElementById('upload').onclick = upload;
     document.getElementById('export-pdf').onclick = () => exporter('pdf');
     document.getElementById('export-html').onclick = () => exporter('html');
+    document.getElementById('preview-html').onclick = preview;
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Notes
- `npm test` échoue car aucun script de test n'est défini.

## Summary
- permettre l'import d'un fichier `resume.json`
- ajouter un aperçu HTML en choisissant le thème
- mettre à jour la page web pour téléverser le fichier et afficher la prévisualisation
- documenter les nouvelles routes API


------
https://chatgpt.com/codex/tasks/task_e_68419edef408832e9b98d09884c658f7