### PR TITLE
Ajout du serveur Express et interface Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Gestion et export de CV
 
-Cette application fournit une petite API Express pour générer un CV puis le télécharger. Une page HTML simple permet de lancer l'export directement depuis le navigateur.
-
-Cette version ajoute la possibilité d'importer un fichier JSON décrivant votre CV,
-de choisir un thème, de prévisualiser le rendu et d'exporter le tout en PDF ou HTML.
+Cette application fournit une API Express pour générer un CV puis le télécharger. Une interface web minimaliste permet d'importer un fichier JSON, de choisir un thème, de prévisualiser le rendu et d'exporter le CV en PDF ou HTML.
 
 ## Installation
 
@@ -11,19 +8,19 @@ de choisir un thème, de prévisualiser le rendu et d'exporter le tout en PDF ou
 npm install
 ```
 
-- Lancer le serveur :
+### Lancer le serveur
 
 ```bash
 npm run start
 ```
 
-Ensuite ouvrez `http://localhost:5000` dans un navigateur pour accéder à l'interface.
+Ouvrez ensuite `http://localhost:5000` dans un navigateur pour accéder à l'interface.
 
 ## API
 
 ### `GET /api/export`
 
-Cette route prend en paramètre `theme`, `format` et `filename`. Elle exécute la commande `resume export` pour générer le fichier demandé (PDF ou HTML) avec le thème sélectionné, puis le renvoie en téléchargement.
+Paramètres `theme`, `format` et `filename`. La route lance la commande `resume export` pour générer le fichier demandé (PDF ou HTML) avec le thème sélectionné, puis renvoie le fichier en téléchargement.
 
 ### `POST /api/upload`
 
@@ -31,4 +28,4 @@ Envoie le contenu d'un fichier JSON contenant votre CV. Le corps de la requête 
 
 ### `GET /api/preview`
 
-Prend un paramètre `theme` et renvoie une page HTML générée à partir du CV importé. Cette route est utilisée pour l'aperçu en ligne dans l'interface.
+Prend un paramètre `theme` et renvoie une page HTML générée à partir du CV importé. Cette route est utilisée pour l'aperçu dans l'interface web.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cv-server",
+  "version": "1.0.0",
+  "description": "API Express pour exporter un CV",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5",
+    "jsonresume": "^4.0.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Gestion de CV</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    #result { margin-top: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>Exporter mon CV</h1>
+  <form id="upload-form">
+    <input type="file" id="file" accept="application/json">
+    <button type="submit">Envoyer le JSON</button>
+  </form>
+
+  <div>
+    <label>Thème : </label>
+    <input type="text" id="theme" value="flat">
+  </div>
+
+  <button id="preview">Prévisualiser</button>
+  <button id="export">Exporter en PDF</button>
+
+  <div id="result"></div>
+
+  <script>
+    const form = document.getElementById('upload-form');
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      const file = document.getElementById('file').files[0];
+      if (!file) return;
+      const json = await file.text();
+      await fetch('/api/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: json
+      });
+      alert('CV import\u00e9');
+    });
+
+    document.getElementById('preview').addEventListener('click', async () => {
+      const theme = document.getElementById('theme').value;
+      const res = await fetch(`/api/preview?theme=${theme}`);
+      const html = await res.text();
+      document.getElementById('result').innerHTML = html;
+    });
+
+    document.getElementById('export').addEventListener('click', () => {
+      const theme = document.getElementById('theme').value;
+      window.location = `/api/export?theme=${theme}&format=pdf&filename=resume`;
+    });
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { exec } = require('child_process');
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.post('/api/upload', (req, res) => {
+  const data = req.body;
+  if (!data) {
+    return res.status(400).send('Aucun contenu');
+  }
+  fs.writeFile('resume.json', JSON.stringify(data, null, 2), err => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Erreur lors de l\'enregistrement');
+    }
+    res.json({ message: 'CV import\u00e9' });
+  });
+});
+
+app.get('/api/export', (req, res) => {
+  const theme = req.query.theme || 'flat';
+  const format = req.query.format || 'pdf';
+  const filename = req.query.filename || 'resume';
+  const output = `${filename}.${format}`;
+
+  const cmd = `npx resume export ${output} --resume resume.json --theme ${theme}`;
+  exec(cmd, err => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Export impossible');
+    }
+    res.download(output, err2 => {
+      if (err2) console.error(err2);
+      fs.unlink(output, () => {});
+    });
+  });
+});
+
+app.get('/api/preview', (req, res) => {
+  const theme = req.query.theme || 'flat';
+  const output = 'preview.html';
+  const cmd = `npx resume export ${output} --resume resume.json --theme ${theme} --format html`;
+  exec(cmd, err => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Pr\u00e9visualisation impossible');
+    }
+    fs.readFile(output, 'utf8', (err2, data) => {
+      if (err2) {
+        console.error(err2);
+        return res.status(500).send('Erreur lecture');
+      }
+      res.send(data);
+      fs.unlink(output, () => {});
+    });
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Serveur en ecoute sur http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Notes
- Implementation d'un serveur Express avec les routes `/api/upload`, `/api/export` et `/api/preview`.
- Creation d'un `package.json` definissant les dependances et le script `start`.
- Ajout d'un dossier `public` contenant `index.html` pour envoyer, previsualiser et exporter un CV.
- Mise a jour du `README.md` pour documenter l'installation et l'utilisation de l'application.

## Tests
- `npm test` echoue car aucun script `test` n'est defini dans `package.json`.


------
https://chatgpt.com/codex/tasks/task_e_6841fb4fab94832e81ff42caac0344da