### PR TITLE
Ajout du serveur Express et interface Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Gestion et export de CV
 
-Cette application fournit une petite API Express pour générer un CV puis le télécharger. Une page HTML simple permet de lancer l'export directement depuis le navigateur.
+Cette application est une petite plateforme web permettant de gérer et d'exporter un CV au format [JSON Resume](https://jsonresume.org/). Elle repose sur Express et l'outil `jsonresume` pour générer l'aperçu ou le fichier final.
 
-Cette version ajoute la possibilité d'importer un fichier JSON décrivant votre CV,
-de choisir un thème, de prévisualiser le rendu et d'exporter le tout en PDF ou HTML.
+L'interface web donne la possibilité de téléverser son fichier JSON, de choisir un thème et le format de sortie puis de prévisualiser ou télécharger le résultat.
 
 ## Installation
 
@@ -11,24 +10,26 @@ de choisir un thème, de prévisualiser le rendu et d'exporter le tout en PDF ou
 npm install
 ```
 
-- Lancer le serveur :
+### Lancer le serveur
 
 ```bash
 npm run start
 ```
 
-Ensuite ouvrez `http://localhost:5000` dans un navigateur pour accéder à l'interface.
+Ensuite ouvrez votre navigateur à l'adresse `http://localhost:5000` pour accéder à l'interface.
+
+Depuis cette page vous pourrez téléverser votre fichier JSON, choisir un thème et un format (PDF ou HTML), prévisualiser le rendu et exporter le fichier généré.
 
 ## API
 
 ### `GET /api/export`
 
-Cette route prend en paramètre `theme`, `format` et `filename`. Elle exécute la commande `resume export` pour générer le fichier demandé (PDF ou HTML) avec le thème sélectionné, puis le renvoie en téléchargement.
+Paramètres `theme`, `format` et `filename`. La route lance la commande `resume export` pour générer le fichier demandé (PDF ou HTML) avec le thème sélectionné, puis renvoie le fichier en téléchargement.
 
 ### `POST /api/upload`
 
-Envoie le contenu d'un fichier JSON contenant votre CV. Le corps de la requête doit être le JSON. Le fichier est enregistré côté serveur et utilisé pour les exports et aperçus.
+Cette route accepte un champ `file` envoyé en `multipart/form-data`. Le fichier JSON est enregistré sous `resume.json` et servira aux fonctions d'aperçu et d'export.
 
 ### `GET /api/preview`
 
-Prend un paramètre `theme` et renvoie une page HTML générée à partir du CV importé. Cette route est utilisée pour l'aperçu en ligne dans l'interface.
+Prend un paramètre `theme` et renvoie le HTML généré à partir du CV importé. Cette route est utilisée pour l'aperçu dans l'interface web.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "cv-server",
+  "version": "1.0.0",
+  "description": "API Express pour exporter un CV",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5",
+    "jsonresume": "^4.0.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Gestion de CV</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    #result { margin-top: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>Exporter mon CV</h1>
+  <form id="upload-form">
+    <input type="file" id="file" accept="application/json">
+    <button type="submit">Envoyer le JSON</button>
+  </form>
+
+  <div>
+    <label>Thème : </label>
+    <input type="text" id="theme" value="flat">
+  </div>
+
+  <div>
+    <label>Format :</label>
+    <select id="format">
+      <option value="pdf">PDF</option>
+      <option value="html">HTML</option>
+    </select>
+  </div>
+
+  <button id="preview">Prévisualiser</button>
+  <button id="export">Exporter</button>
+
+  <div id="result"></div>
+
+  <script>
+    const form = document.getElementById('upload-form');
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      const file = document.getElementById('file').files[0];
+      if (!file) return;
+      const data = new FormData();
+      data.append('file', file);
+      await fetch('/api/upload', {
+        method: 'POST',
+        body: data
+      });
+      alert('CV importé');
+    });
+
+    document.getElementById('preview').addEventListener('click', async () => {
+      const theme = document.getElementById('theme').value;
+      const res = await fetch(`/api/preview?theme=${theme}`);
+      const html = await res.text();
+      document.getElementById('result').innerHTML = html;
+    });
+
+    document.getElementById('export').addEventListener('click', () => {
+      const theme = document.getElementById('theme').value;
+      const format = document.getElementById('format').value;
+      window.location = `/api/export?theme=${theme}&format=${format}&filename=resume`;
+    });
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { exec } = require('child_process');
+const multer = require('multer');
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+const upload = multer({ storage: multer.memoryStorage() });
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.post('/api/upload', upload.single('file'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).send('Aucun fichier');
+  }
+  fs.writeFile('resume.json', req.file.buffer, err => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send("Erreur lors de l'enregistrement");
+    }
+    res.json({ message: 'CV importé' });
+  });
+});
+
+app.get('/api/export', (req, res) => {
+  const theme = req.query.theme || 'flat';
+  const format = req.query.format || 'pdf';
+  const filename = req.query.filename || 'resume';
+  const output = `${filename}.${format}`;
+
+  const cmd = `npx resume export ${output} --resume resume.json --theme ${theme}`;
+  exec(cmd, err => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Export impossible');
+    }
+    res.download(output, err2 => {
+      if (err2) console.error(err2);
+      fs.unlink(output, () => {});
+    });
+  });
+});
+
+app.get('/api/preview', (req, res) => {
+  const theme = req.query.theme || 'flat';
+  const output = 'preview.html';
+  const cmd = `npx resume export ${output} --resume resume.json --theme ${theme} --format html`;
+  exec(cmd, err => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Pr\u00e9visualisation impossible');
+    }
+    fs.readFile(output, 'utf8', (err2, data) => {
+      if (err2) {
+        console.error(err2);
+        return res.status(500).send('Erreur lecture');
+      }
+      res.send(data);
+      fs.unlink(output, () => {});
+    });
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Serveur en ecoute sur http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Notes
- Ajout de multer pour gérer l'envoi du fichier JSON
- Formulaire web mis à jour avec choix du format et envoi via `multipart/form-data`
- Documentation complétée pour expliquer l'utilisation de l'interface

## Tests
- `npm test` affiche "No tests specified"

------
https://chatgpt.com/codex/tasks/task_e_6841fb4fab94832e81ff42caac0344da